### PR TITLE
修复 & 优化: `font-family` 参数失灵 & 优先使用本地字体资源

### DIFF
--- a/packages/subsets/src/templates/css.ts
+++ b/packages/subsets/src/templates/css.ts
@@ -44,7 +44,7 @@ export const createCSS = (
     const css = opts.css || {};
     const family =
         // fontData.preferredFamily  不使用这个，因为这个容易引起歧义
-        fontData.fontFamily || css.fontFamily;
+        css.fontFamily || fontData.fontFamily;
 
     const preferredSubFamily =
         fontData.preferredSubFamily || fontData.fontSubFamily || "";
@@ -56,7 +56,7 @@ export const createCSS = (
         .map(({ path, unicodeRange }) => {
             return `@font-face {
 font-family: "${family}";
-src: url("./${path}");
+src: local("${ fontData.fontFamily }"), url("./${path}");
 font-style: ${style};
 font-weight: ${weight};
 font-display: ${css.fontDisplay || "swap"};


### PR DESCRIPTION
> 此 PR 包含 1 处修复与 1 处优化。

## 关于修复

### 问题描述

`fontSplit` 的 `fontFamily` 参数无法自定义生成的 `.css` 文件的 `font-family` 属性值，即无论 `fontFamily` 参数的值为何，`.css` 文件的 `font-family` 属性的值恒定为字体文件的原生名字。示例如下：

``` ts
fontSplit({ css: {
    fontFamily: "my-name", // 此参无效
}})
```

### 解决

该 bug 是由 `css.ts` 文件中的逻辑判断失误所导致的，目前已更正。

``` ts
// 更正前的逻辑判断
const family = fontData.fontFamily || css.fontFamily;

// 更正后的逻辑判断
const family = css.fontFamily || fontData.fontFamily;
```

## 关于优化

我为 `.css` 文件的 `font-face` 的 `src` 属性增加了 `local` 函数，效果如下：

``` css
@font-face {
    /* 修改前 */
    src: url("./38bba2dad625c106d26e9d446103a066.woff2");

    /* 修改后 */
    src: local("Fira Code"), url("./38bba2dad625c106d26e9d446103a066.woff2");
}
```

`local` 函数用于查找并使用客户端本地的字体资源，举个例子：假设网页需要渲染 `Fira Code` 字体，`local` 函数会查找客户端本地是否安装了该字体，如果安装了，则直接使用该字体，如果没有安装，则再发起网络请求/使用缓存资源。

> 我使用了字体文件原生的名字来作为 `local` 函数的参数，比如 `local("Fira Code")`、`local("LXGW WenKai")`，在 `Windows 10` 和 `macOS Ventura` 上，`local` 函数都可以成功找到本地字体资源。
