### PR TITLE
修复: CSS 文件（如 `result.css`）中包含非法分号

### DIFF
--- a/packages/subsets/src/templates/css.ts
+++ b/packages/subsets/src/templates/css.ts
@@ -97,7 +97,7 @@ font-style: ${style};
 font-weight: ${weight};
 font-display: ${css.fontDisplay || 'swap'};
 unicode-range:${unicodeRange};
-};`;
+}`;
             return css.compress !== false ? str.replace(/\n/g, '') : str;
         })
         .join('\n');


### PR DESCRIPTION
## 描述

该库在分割完一份字体文件之后，便会输出一份相应的 CSS 文件（如 `result.css` 即为其默认命名）。然而，该 CSS 文件中的每一则 `rule` 的末尾都含有一个非法的分号，该分号会破坏样式表。

下面是一例虚构的 `result.css` 的部分内容：

```css
@font-face { unicode-range: U+2e3a; }; /* 👈 非法的分号 */
@font-face { unicode-range: U+25c4; }; /* 👈 非法的分号 */
@font-face { unicode-range: U+25c0; }; /* 👈 非法的分号 */
```

> `rule` 是什么？比如 `{ padding: 1rem }` 就是一则 `rule`。

<br />

## 措施

我认为应当剔除掉该非法的分号，于是我剔除掉了 `createCSS` 中的模版字符串末尾的 `;`，因为该模版字符串的内容正是 `result.css` 的内容。