### PR TITLE
renameOutputFont 支持自行实现哈希算法

### DIFF
--- a/packages/subsets/README.md
+++ b/packages/subsets/README.md
@@ -76,6 +76,10 @@ fontSplit({
         // fontFamily: "站酷庆科黄油体",
         // fontWeight: 400,
     },
+    renameOutputFont: '[hash:10][ext]', // 自定义分包输出的文件名为 10 位短哈希，或者使用自增索引: '[index][ext]'
+    // renameOutputFont: ({ transferred, ext, index }) => {
+    //   return index.toString(36) + ext
+    // } // 或者也可以像这样传入一个函数返回自定义的文件名
 });
 ```
 

--- a/packages/subsets/src/interface.ts
+++ b/packages/subsets/src/interface.ts
@@ -1,6 +1,7 @@
 import { FontType } from './utils/detectFormat';
 import { WriteFileOptions } from 'fs-extra';
 import type { Buffer } from 'buffer';
+import type { ReplaceProps } from './useSubset/templateReplacer';
 /** subset 切割完毕后的数据格式 */
 export type SubsetResult = {
     unicodeRange: string;
@@ -107,9 +108,7 @@ export type InputTemplate = {
         settings?: ISettingsParam<unknown>;
     };
     /** 自定义输出字体名称，优先于 outputFile，用于缩短字体文件名称 */
-    renameOutputFont?:
-        | string
-        | ((hash: string, ext: string, index: number) => string);
+    renameOutputFont?: string | ((replaceProps: ReplaceProps) => string);
     /** 输出文件的方式，如果你需要在特定的平台使用，那么需要适配这个函数 */
     outputFile?: IOutputFile;
 };

--- a/packages/subsets/src/templates/reporter.ts
+++ b/packages/subsets/src/templates/reporter.ts
@@ -27,7 +27,7 @@ export const createReporter = async (
 ) => {
     const data = subsetResult.map((i) => {
         return {
-            name: i.filename || i.path,
+            name: i.path,
             size: i.size,
             chars: i.unicodeRange,
             diff: i.diff,

--- a/packages/subsets/src/useSubset/createRecord.ts
+++ b/packages/subsets/src/useSubset/createRecord.ts
@@ -1,7 +1,6 @@
 import { UnicodeRange } from '@japont/unicode-range';
 import { IOutputFile, InputTemplate, SubsetResult } from '../interface';
-import md5 from '../utils/md5';
-import { templateReplace } from './templateReplacer';
+import { templateReplace, type ReplaceProps } from './templateReplacer';
 export async function createRecord(
     outputFile: IOutputFile,
     ext: string,
@@ -12,14 +11,15 @@ export async function createRecord(
     index: number
 ): Promise<SubsetResult[0]> {
     const renameOutputFont = input.renameOutputFont || '[hash][ext]';
+    const replaceProps: ReplaceProps = {
+        transferred,
+        ext,
+        index,
+    };
     const filename =
         typeof renameOutputFont === 'string'
-            ? templateReplace(renameOutputFont, {
-                  hash: () => md5(transferred),
-                  index,
-                  ext,
-              })
-            : renameOutputFont(md5(transferred), ext, index);
+            ? templateReplace(renameOutputFont, replaceProps)
+            : renameOutputFont(replaceProps);
 
     await outputFile(filename, transferred);
     const str = UnicodeRange.stringify(subset);

--- a/packages/subsets/src/useSubset/templateReplacer.ts
+++ b/packages/subsets/src/useSubset/templateReplacer.ts
@@ -1,5 +1,7 @@
+import md5 from '../utils/md5';
+
 export interface ReplaceProps {
-    hash: () => string;
+    transferred: Uint8Array;
     ext: string;
     index: number;
 }
@@ -13,7 +15,9 @@ export const templateReplace = (template: string, data: ReplaceProps) => {
     replacements.set('index', createReplacer(data.index.toString()));
     replacements.set('ext', createReplacer(data.ext));
     // hash
-    const hashReplacer = createLengthReplacer(createReplacer(data.hash));
+    const hashReplacer = createLengthReplacer(
+        createReplacer(() => md5(data.transferred))
+    );
     replacements.set('hash', hashReplacer);
     replacements.set('md5', hashReplacer);
 

--- a/packages/subsets/test/node.test.mjs
+++ b/packages/subsets/test/node.test.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import { fontSplit } from '../dist/index.js';
+import crypto from 'node:crypto'
 // const buffer = await fs.readFile(
 //     "./node_modules/@konghayao/harfbuzzjs/hb-subset.wasm"
 // );
@@ -22,7 +23,9 @@ fontSplit({
     // threads: {},
     // renameOutputFont: '[hash:10][ext]',
     // renameOutputFont: '[index][ext]',
-    // renameOutputFont(hash, ext, index) {
+    // renameOutputFont({ transferred, ext, index }) {
+    //     const algorithm = 'sha256'
+    //     const hash = crypto.createHash(algorithm).update(transferred).digest('hex')
     //     // return index.toString() + ext // index 命名
     //     return hash.slice(0, 6) + ext // 短 hash 命名
     // }


### PR DESCRIPTION
#17 已经合并不能继续 commit 所以另外开个 PR。

主要处理几个问题：

1. 自定义 `renameOutputFont` 时，仍然有可能不会用到 hash，直接将分包数据交给函数内部处理可以避免不必要的开支，并且可以更灵活的自行实现哈希算法，例如使用 [xxHash](https://github.com/Cyan4973/xxHash) 等。
  https://github.com/KonghaYao/cn-font-split/blob/57ee036a3c764b62fbad9ca95b23ed312bd6db5a/packages/subsets/src/useSubset/createRecord.ts#L22
2. 同步更新生成报告中的类型 https://github.com/KonghaYao/cn-font-split/commit/ee8bc92ad97b843edfb59494998c5a2e4ab5e7d4 。
3. 更新文档。



