### PR TITLE
修复: 无法在 node v21.5.0 中工作

### DIFF
--- a/packages/subsets/src/convert/font-converter.node.ts
+++ b/packages/subsets/src/convert/font-converter.node.ts
@@ -43,5 +43,7 @@ export const convert = async function (
     if (toFormat === 'woff2') {
         buffer = await convertTTFToWOFF2Async(buffer as Buffer);
     }
+
+    buffer = new Uint8Array(buffer);
     return buffer;
 };


### PR DESCRIPTION
## 描述

关于 Node.js 的测试用例无法工作。

Terminal 将会“打印出「分包失败」关键字”，`./packages/subsets/temp/node` 文件夹中没有出现任何子集化的字体文件。

> bun v1.0.20 和 deno v1.39.1 均可正常工作。

### 重现

1. 拉取最新的官方仓库
2. 执行 `pnpm i`
3. 进入 `./packages/subsets` 目录
4. 执行 `pnpm test:node`

### 环境

- M1 Pro, macOS Ventura 13.3.1 (a)
- Node.js v21.5.0 (截至PR时刻的最新版本)

<br />

## 解决

将 `font-converter.node.ts` 的返回值明确的转换为 `Uint8Array` 实例即可。

> 为什么转换为 `Uint8Array`？1）`font-converter.node.ts` 中的 `convert` 的其中一种返回值就是 `Uint8Array` 实例；2）`convertTTFToWOFF2Async` 方法的 [源码](https://github.com/Brooooooklyn/woff-build/blob/main/src/lib.rs) 的返回值（`JsBuffer`）在 Node.js 中即以 `Uint8Array` 的形式存在；