### PR TITLE
Add missing font weight

### DIFF
--- a/packages/subsets/src/templates/css/subFamilyToWeight.ts
+++ b/packages/subsets/src/templates/css/subFamilyToWeight.ts
@@ -7,6 +7,8 @@ const doubleFontWeightName = new Map([
     ['demi bold', 600],
 ]);
 const singleFontWeightName = new Map([
+    ['thin', 100],
+    ['hairline', 100],
     ['light', 300],
     ['normal', 400],
     ['regular', 400],


### PR DESCRIPTION
Thin font weight (100) is missing.

https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight#common_weight_name_mapping

## Summary by Sourcery

Bug Fixes:
- Add missing font weight mappings for 'thin' and 'hairline' with a value of 100.