### PR TITLE
chore: only publish `dist` folder

### DIFF
--- a/packages/ffi-js/package.json
+++ b/packages/ffi-js/package.json
@@ -8,6 +8,9 @@
     "bin": {
         "cn-font-split": "./dist/cli.js"
     },
+    "files": [
+        "dist"
+    ],
     "publishConfig": {
         "registry": "https://registry.npmjs.org/",
         "access": "public"

--- a/packages/ffi-js/package.json
+++ b/packages/ffi-js/package.json
@@ -9,6 +9,7 @@
         "cn-font-split": "./dist/cli.js"
     },
     "files": [
+        "!**/*.map",
         "dist"
     ],
     "publishConfig": {

--- a/packages/font-analyze/package.json
+++ b/packages/font-analyze/package.json
@@ -4,6 +4,9 @@
     "description": "a font analyze tool for Chinese Charset Check",
     "main": "dist/index.js",
     "type": "module",
+    "files": [
+        "dist"
+    ],
     "scripts": {
         "build": "tsc",
         "prepublish": "pnpm build && node script/build.mjs",

--- a/packages/font-analyze/package.json
+++ b/packages/font-analyze/package.json
@@ -5,6 +5,7 @@
     "main": "dist/index.js",
     "type": "module",
     "files": [
+        "data",
         "dist"
     ],
     "scripts": {

--- a/packages/font-replacer/package.json
+++ b/packages/font-replacer/package.json
@@ -4,6 +4,9 @@
     "description": "font-replacer 是中文网字计划用于动态加载、动态更换字体所使用的库。你也可以自定义字体源来加载自己的字体，默认使用了字图 CDN的庞大字体库来源！",
     "main": "./dist/index.js",
     "type": "module",
+    "files": [
+        "dist"
+    ],
     "publishConfig": {
         "access": "public"
     },

--- a/packages/font-sharp/package.json
+++ b/packages/font-sharp/package.json
@@ -4,6 +4,9 @@
     "description": "font to SVG Render.",
     "main": "dist/font-sharp/src/index.js",
     "type": "module",
+    "files": [
+        "dist"
+    ],
     "repository": {
         "type": "git",
         "url": "https://github.com/KonghaYao/cn-font-split/tree/ts/packages/font-sharp"

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/proto-to-cli/package.json
+++ b/packages/proto-to-cli/package.json
@@ -7,6 +7,9 @@
     "bin": {
         "proto-to-cli": "dist/cli.js"
     },
+    "files": [
+        "dist"
+    ],
     "publishConfig": {
         "registry": "https://registry.npmjs.org/",
         "access": "public"

--- a/packages/proto-to-cli/package.json
+++ b/packages/proto-to-cli/package.json
@@ -8,6 +8,7 @@
         "proto-to-cli": "dist/cli.js"
     },
     "files": [
+        "!**/*.map",
         "dist"
     ],
     "publishConfig": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -14,8 +14,7 @@
         "access": "public"
     },
     "files": [
-        "dist",
-        "src"
+        "dist"
     ],
     "author": "KonghaYao<dongzhongzhidong@qq.com>",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add a `"files"` field to the `package.json` files of multiple packages, specifying that only the `dist` folder should be published.