### PR TITLE
feat: expose configurable subsetsChunkSize

### DIFF
--- a/packages/vite/src/subset/index.ts
+++ b/packages/vite/src/subset/index.ts
@@ -20,9 +20,10 @@ function chunk(arr?: number[], size = 500) {
     }
 }
 
-export type BundlePluginConfig = Partial<proto.InputTemplate> & {
+export type BundlePluginConfig = Omit<Partial<proto.InputTemplate>, 'input' | 'subsets'> & {
     cacheDir?: string;
     server?: boolean;
+    subsetChunkSize?: number
 };
 
 export class BundlePlugin {
@@ -89,7 +90,7 @@ export class BundlePlugin {
                 fontFeature: true,
                 reduceMins: !onlySubset,
                 subsetRemainChars: !onlySubset,
-                subsets: onlySubset ? chunk(this.subsets?.flat()) : undefined,
+                subsets: onlySubset ? chunk(this.subsets?.flat(), this.config.subsetChunkSize) : undefined,
                 silent: true,
             }).catch((e) => {
                 console.error(e);


### PR DESCRIPTION
feat: expose configurable subsetsChunkSize

## Summary by Sourcery

Expose `subsetChunkSize` in plugin config and apply it when chunking font subsets

New Features:
- Allow customizing subset chunk size in font splitting via `subsetChunkSize` config option

Enhancements:
- Omit `input` and `subsets` fields from `BundlePluginConfig` to prevent unintended overrides