### PR TITLE
修改示例代码中错误的符号名称

### DIFF
--- a/packages/font-replacer/README.md
+++ b/packages/font-replacer/README.md
@@ -21,7 +21,7 @@ import { FontReplacer, getChineseFontsMap } from 'cn-font-replacer';
 // 获取中文网字计划的 字图 CDN 的相应数据
 const CNFontMap = await getChineseFontsMap();
 
-console.log(CDFontMap);
+console.log(CNFontMap);
 
 // 注入到 FontReplacer 实例
 const fontReplacer = new FontReplacer(CNFontMap);


### PR DESCRIPTION
在Font Replacer中，可以发现README中给出的示例代码`CNFontMap`被错误写为了`CDFontMap`导致示例代码实际上无法正常共工作，遂修改之

## Summary by Sourcery

Documentation:
- Correct the example output variable in README from CDFontMap to CNFontMap to ensure it works as intended