### PR TITLE
fix: enhance ZH_SYMBOL Unicode range with additional Chinese punctuation marks

### DIFF
--- a/crates/lang_unicodes/src/lib.rs
+++ b/crates/lang_unicodes/src/lib.rs
@@ -26,6 +26,7 @@ lazy_static! {
     // 定义 ZH_SYMBOL 静态引用，包含特化处理的中文常用符号的 Unicode 码点
     // 参考 https://www.w3.org/International/clreq/#tables_of_chinese_punctuation_marks
     // 以及 https://zh.wikipedia.org/wiki/%E6%A0%87%E7%82%B9%E7%AC%A6%E5%8F%B7
+    // 。．，、：；！‼？⁇⸺——…⋯～-–·・‧/／「」『』“”‘’（）《》〈〉【】〖〗〔〕［］｛｝＿﹏●•－｜﹁﹂﹃﹄〘〙
     pub static ref ZH_SYMBOL: Vec<u32> = expand_ranges(&[
         // 句号
         (0x3002, 0x3002), // 。

--- a/crates/lang_unicodes/src/lib.rs
+++ b/crates/lang_unicodes/src/lib.rs
@@ -76,7 +76,6 @@ lazy_static! {
         (0x3010, 0x3011), // 【】
         (0x3016, 0x3017), // 〖〗
         (0x3014, 0x3015), // 〔〕
-        (0x3018, 0x3019), // 〘〙
         (0xFF3B, 0xFF3B), // ［
         (0xFF3D, 0xFF3D), // ］
         (0xFF5B, 0xFF5B), // ｛
@@ -91,6 +90,7 @@ lazy_static! {
         (0xFF5C, 0xFF5C), // ｜（全角竖线）
         (0xFE41, 0xFE42), // ﹁﹂
         (0xFE43, 0xFE44), // ﹃﹄
+        (0x3018, 0x3019), // 〘〙
     ]);
 
     pub static ref HALFWIDTH_FULLWIDTH: Vec<u32> = expand_ranges(&[(0xFF00, 0xFFEF)]);

--- a/crates/lang_unicodes/src/lib.rs
+++ b/crates/lang_unicodes/src/lib.rs
@@ -24,32 +24,73 @@ lazy_static! {
     pub static ref IPA_SYMBOLS: Vec<u32> = expand_ranges(&[(0x0250, 0x02FF)]);
 
     // 定义 ZH_SYMBOL 静态引用，包含特化处理的中文常用符号的 Unicode 码点
+    // 参考 https://www.w3.org/International/clreq/#tables_of_chinese_punctuation_marks
+    // 以及 https://zh.wikipedia.org/wiki/%E6%A0%87%E7%82%B9%E7%AC%A6%E5%8F%B7
     pub static ref ZH_SYMBOL: Vec<u32> = expand_ranges(&[
-        // …
-        (0x2026, 0x2026),
-        // 句号（、。）
-        (0x3001, 0x3002),
-        //《》
-        (0x300a, 0x300b),
-        // 逗号（，－）
-        (0xFF0C, 0xFF0D),
-        // 问号（？）
-        (0xFF1F, 0xFF1F),
-        // ｜
-        (0xFF5C, 0xFF5C),
-        // 感叹号（！）
-        (0xFF01, 0xFF01),
-        // 分号（；）
-        (0xFF1B, 0xFF1B),
-        // 括号（（））
-        (0xFF08, 0xFF09),
-        // 冒号（：）
-        (0xFF1A, 0xFF1A),
-        // 引号（“” ‘’）
+        // 句号
+        (0x3002, 0x3002), // 。
+        (0xFF0E, 0xFF0E), // ．
+        // 逗号
+        (0xFF0C, 0xFF0C), // ，
+        // 顿号
+        (0x3001, 0x3001), // 、
+        // 冒号
+        (0xFF1A, 0xFF1A), // ：
+        // 分号
+        (0xFF1B, 0xFF1B), // ；
+        // 叹号
+        (0xFF01, 0xFF01), // ！
+        (0x203C, 0x203C), // ‼
+        // 问号
+        (0xFF1F, 0xFF1F), // ？
+        (0x2047, 0x2047), // ⁇
+        // 破折号
+        (0x2E3A, 0x2E3A), // ⸺
+        (0x2014, 0x2014), // ——
+        // 省略号
+        (0x2026, 0x2026), // …
+        (0x22EF, 0x22EF), // ⋯
+        // 连接号
+        (0xFF5E, 0xFF5E), // ～
+        (0x002D, 0x002D), // -
+        (0x2013, 0x2013), // –
+        // (0x2014, 0x2014), // — 与上面的破折号重复
+        // 间隔号
+        (0x00B7, 0x00B7), // ·
+        (0x30FB, 0x30FB), // ・
+        (0x2027, 0x2027), // ‧
+        // 分隔号
+        (0x002F, 0x002F), // /
+        (0xFF0F, 0xFF0F), // ／
+        // 引号
+        (0x300C, 0x300D), // 「」
+        (0x300E, 0x300F), // 『』
         (0x201C, 0x201D), // “”
         (0x2018, 0x2019), // ‘’
-        // 破折号（——）
-        (0x2014, 0x2014),
+        // 括号
+        (0xFF08, 0xFF09), // （）
+        // 书名号
+        (0x300A, 0x300B), // 《》
+        (0x3008, 0x3009), // 〈〉
+        // 其他夹注符号
+        (0x3010, 0x3011), // 【】
+        (0x3016, 0x3017), // 〖〗
+        (0x3014, 0x3015), // 〔〕
+        (0x3018, 0x3019), // 〘〙
+        (0xFF3B, 0xFF3B), // ［
+        (0xFF3D, 0xFF3D), // ］
+        (0xFF5B, 0xFF5B), // ｛
+        (0xFF5D, 0xFF5D), // ｝
+        // 行间标号
+        (0xFF3F, 0xFF3F), // ＿
+        (0xFE4F, 0xFE4F), // ﹏
+        (0x25CF, 0x25CF), // ●
+        (0x2022, 0x2022), // •
+        // 额外补充
+        (0xFF0D, 0xFF0D), // －（全角连字符）
+        (0xFF5C, 0xFF5C), // ｜（全角竖线）
+        (0xFE41, 0xFE42), // ﹁﹂
+        (0xFE43, 0xFE44), // ﹃﹄
     ]);
 
     pub static ref HALFWIDTH_FULLWIDTH: Vec<u32> = expand_ranges(&[(0xFF00, 0xFFEF)]);


### PR DESCRIPTION
fixes https://github.com/KonghaYao/cn-font-split/issues/192

1. 按《[中文排版需求](https://www.w3.org/International/clreq/#tables_of_chinese_punctuation_marks)》标准顺序添加所有中文标点符号
2. 保留代码原有的 `0xFF0D`、`0xFF5C`
3. 补充 ﹁﹂﹃﹄〘〙

## Summary by Sourcery

Enhance the ZH_SYMBOL Unicode range by fully aligning it with the CLREQ list of Chinese punctuation marks, standardizing the order, and supplementing missing symbols including ﹁﹂﹃﹄ while preserving legacy code points

New Features:
- Expand ZH_SYMBOL to include the full set of Chinese punctuation marks in standard order per the CLREQ specification
- Add additional decorative marks ﹁﹂﹃﹄ to ZH_SYMBOL

Enhancements:
- Retain existing full-width hyphen (0xFF0D) and vertical bar (0xFF5C) in ZH_SYMBOL